### PR TITLE
🕶️ [github-contrib] viewer display origin

### DIFF
--- a/individuals/github-contrib/daily-ranking-viewer/daily-ranking-viewer.go
+++ b/individuals/github-contrib/daily-ranking-viewer/daily-ranking-viewer.go
@@ -262,7 +262,7 @@ func (m model) View() string {
 		} else if lastIdx, ok := m.lastCommitDate[c.Login]; ok {
 			daysSince := m.currentIndex - lastIdx
 			if daysSince > 100 {
-				todayStr = m.relaxingStyle.Render(" (relaxing)")
+				todayStr = m.relaxingStyle.Render(fmt.Sprintf(" (relaxing for %d days)", daysSince))
 			}
 		}
 


### PR DESCRIPTION
## Done

- 🕶️ [github-contrib] viewer display origin
- show relaxing for >100 days
- show the number of relaxing days


## Meta

(Automated in `.just/gh-process.just`.)
