### PR TITLE
🪗 [github] Fix R package cache corruption in GitHub workflow

### DIFF
--- a/.github/workflows/github-update.yml
+++ b/.github/workflows/github-update.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-4.4
+          key: ${{ runner.os }}-r-4.4-v2
 
       - name: Setup just
         uses: extractions/setup-just@v2

--- a/justfile
+++ b/justfile
@@ -416,7 +416,14 @@ install-r-package PACKAGE:
 	echo ""
 
 	# Check if package is already installed and get version
-	INSTALLED_VERSION=$(R --quiet --no-save -e "if ('{{PACKAGE}}' %in% installed.packages()[,'Package']) { cat(as.character(packageVersion('{{PACKAGE}}'))) } else { cat('NOT_INSTALLED') }" 2>/dev/null | tail -1)
+	INSTALLED_VERSION=$(R --quiet --no-save -e "
+	tryCatch({
+	  library('{{PACKAGE}}', character.only = TRUE)
+	  cat(as.character(packageVersion('{{PACKAGE}}')))
+	}, error = function(e) {
+	  cat('NOT_INSTALLED')
+	})
+	" 2>/dev/null | tail -1)
 
 	if [ "$INSTALLED_VERSION" != "NOT_INSTALLED" ]; then
 		echo "{{YELLOW}}Package {{PACKAGE}} is already installed (version $INSTALLED_VERSION){{NORMAL}}"


### PR DESCRIPTION
## Done

- 🪗 [github] Fix R package cache corruption in GitHub workflow


## Meta

(Automated in `.just/gh-process.just`.)
