### PR TITLE
🔕 [github] explict permissions fix checkov warning

### DIFF
--- a/.github/workflows/github-update.yml
+++ b/.github/workflows/github-update.yml
@@ -1,10 +1,12 @@
 ---
-# checkov:skip=CKV2_GHA_1:Write permissions needed to create branches and PRs
 name: GitHub Update
 on:
   schedule:
     - cron: '0 12 * * *'
   workflow_dispatch:
+
+# global permissions
+permissions: {}
 
 jobs:
   update:


### PR DESCRIPTION
## Done

- 🔕 [github] disable checkov warning for one job
- does it need to be at the top of the file?
- move skip line down by one
- oh, explicit permisisons at the top level


## Meta

(Automated in `.just/gh-process.just`.)



