### PR TITLE
⏱️ [github] countdown 60s at the end in daily-ranking-viewer to leave time for end screen on youtube

### DIFF
--- a/individuals/github-contrib/daily-ranking-viewer/daily-ranking-viewer.go
+++ b/individuals/github-contrib/daily-ranking-viewer/daily-ranking-viewer.go
@@ -78,7 +78,7 @@ type model struct {
 
 const controlsLine = "Controls: [space] pause/play │ [h/l] prev/next │ [g/;] ±100 days │ [j/k] speed │ [r] restart │ [q] quit"
 
-const countdownSeconds = 10
+const countdownSeconds = 60
 
 func initialModel(stats []DailyStats, topN int, speed time.Duration) model {
 	for i := range stats {


### PR DESCRIPTION
## Done

- ⏱️ [github] countdown 60s at the end in daily-ranking-viewer to leave time for end screen on youtube


## Meta

(Automated in `.just/gh-process.just`.)
