### PR TITLE
🪙 [github-update] use PAT token for PR creation to allow other GHAs to trigger

### DIFF
--- a/.github/workflows/github-update.yml
+++ b/.github/workflows/github-update.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PR_CREATION }}
           BRANCH_NAME: ${{ steps.branch.outputs.branch_name }}
           RANDOM_EMOJI: ${{ steps.emoji.outputs.emoji }}
         run: |


### PR DESCRIPTION
Fixes #358

<!-- PR_BODY_DONE_START -->
## Done

- 🪙 [github-update] use PAT token for PR creation to allow other GHAs to trigger

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)
